### PR TITLE
Preserve filters when navigating via property links

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -672,24 +672,28 @@ const getConnectedEndpointPaths = (path: string): string[] => {
 };
 
 const focusNodeByPath = (path: string) => {
-	const target = nodeByPath.get(path);
-	if (!target) {
-		return;
-	}
+        const target = nodeByPath.get(path);
+        if (!target) {
+                return;
+        }
 
-	let layoutToUse = filteredLayout;
-	if (layoutToUse && !layoutToUse.nodes.some((node) => node.node.path === path)) {
-		clearSearch();
-		layoutToUse = currentLayout;
-	} else if (!layoutToUse) {
-		layoutToUse = currentLayout;
-	}
+        const hasActiveFilters = Boolean(activeFilterNormalized) || activeStatusFilter !== "all";
+        if (hasActiveFilters) {
+                const currentlyVisible =
+                        filteredLayout?.nodes.some((node) => node.node.path === path) ?? false;
+                if (!currentlyVisible) {
+                        ensureForcedVisibility(path);
+                        shouldAutoFitView = true;
+                        applyFilters();
+                }
+        }
 
-	if (!layoutToUse) {
-		return;
-	}
+        const layoutToUse = filteredLayout ?? currentLayout;
+        if (!layoutToUse) {
+                return;
+        }
 
-	let layoutNode = findLayoutNodeByPath(path, layoutToUse);
+        let layoutNode = findLayoutNodeByPath(path, layoutToUse);
 	if (!layoutNode && layoutToUse !== currentLayout) {
 		layoutNode = findLayoutNodeByPath(path, currentLayout);
 	}


### PR DESCRIPTION
## Summary
- avoid clearing the active filter when following node links from the details panel
- force the linked node into the filtered layout and reapply filters so it becomes visible

## Testing
- bun test
- bun run bundle

------
https://chatgpt.com/codex/tasks/task_e_68df9c38670c83269c719ff7fa35cc6a