### PR TITLE
Refine property reference heuristics

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -437,16 +437,18 @@ type PropertyReference = {
 };
 
 const collectPropertyReferences = (
-	property: DtsProperty,
+        property: DtsProperty,
 ): PropertyReference[] => {
-	const references: PropertyReference[] = [];
-	const seen = new Set<string>();
-	const nameLower = property.name.toLowerCase();
-	const allowNumeric =
-		HANDLE_PROPERTY_NAMES.has(nameLower) ||
-		property.type === "cell-list" ||
-		property.type === "number" ||
-		property.type === "mixed";
+        const references: PropertyReference[] = [];
+        const seen = new Set<string>();
+        const nameLower = property.name.toLowerCase();
+        const raw = property.raw ?? "";
+        const containsExplicitLabel = /&[A-Za-z_][\w.-]*/.test(raw);
+        const allowNumeric =
+                HANDLE_PROPERTY_NAMES.has(nameLower) ||
+                containsExplicitLabel ||
+                property.type === "number" ||
+                property.type === "mixed";
 
 	const addReference = (
 		target: DtsNode,


### PR DESCRIPTION
## Summary
- avoid treating data-only cell lists as numeric references by requiring either explicit labels or known handle properties
- add regression tests that parse the bundled DTS examples, including brightness-level checks

## Testing
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68e482c0393c8326b94e3543285e33e5