### PR TITLE
Add interactive register map viewer

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -36,6 +36,17 @@ const warningsToggleLabel = document.querySelector<HTMLLabelElement>(
 	"#warnings-toggle-label",
 );
 const warningsPanel = document.querySelector<HTMLPreElement>("#warnings-panel");
+const registerMapStatus = document.querySelector<HTMLParagraphElement>(
+	"#register-map-status",
+);
+const registerMapTrack = document.querySelector<HTMLDivElement>(
+	"#register-map-track",
+);
+const registerMapLegend = document.querySelector<HTMLDivElement>(
+	"#register-map-legend",
+);
+const registerMapAxis =
+	document.querySelector<HTMLDivElement>("#register-map-axis");
 
 const ctx = canvas?.getContext("2d");
 
@@ -437,18 +448,18 @@ type PropertyReference = {
 };
 
 const collectPropertyReferences = (
-        property: DtsProperty,
+	property: DtsProperty,
 ): PropertyReference[] => {
-        const references: PropertyReference[] = [];
-        const seen = new Set<string>();
-        const nameLower = property.name.toLowerCase();
-        const raw = property.raw ?? "";
-        const containsExplicitLabel = /&[A-Za-z_][\w.-]*/.test(raw);
-        const allowNumeric =
-                HANDLE_PROPERTY_NAMES.has(nameLower) ||
-                containsExplicitLabel ||
-                property.type === "number" ||
-                property.type === "mixed";
+	const references: PropertyReference[] = [];
+	const seen = new Set<string>();
+	const nameLower = property.name.toLowerCase();
+	const raw = property.raw ?? "";
+	const containsExplicitLabel = /&[A-Za-z_][\w.-]*/.test(raw);
+	const allowNumeric =
+		HANDLE_PROPERTY_NAMES.has(nameLower) ||
+		containsExplicitLabel ||
+		property.type === "number" ||
+		property.type === "mixed";
 
 	const addReference = (
 		target: DtsNode,
@@ -897,10 +908,364 @@ type PropertyLink = PropertyReference;
 const resolvePropertyLinks = (property: DtsProperty): PropertyLink[] =>
 	collectPropertyReferences(property);
 
+type RegisterRange = {
+	node: DtsNode;
+	base: bigint;
+	size: bigint;
+	end: bigint;
+};
+
+type CellSpec = {
+	addressCells: number;
+	sizeCells: number;
+};
+
+const DEFAULT_CELL_SPEC: CellSpec = {
+	addressCells: 1,
+	sizeCells: 1,
+};
+
+const REGISTER_COLOR_PALETTE = [
+	"#2563eb",
+	"#16a34a",
+	"#d97706",
+	"#dc2626",
+	"#7c3aed",
+	"#0891b2",
+	"#f97316",
+	"#0f766e",
+	"#a855f7",
+	"#9333ea",
+];
+
+let registerRanges: RegisterRange[] = [];
+const registerColorByPath = new Map<string, string>();
+
+const formatBigIntHex = (value: bigint): string => `0x${value.toString(16)}`;
+
+const formatByteSize = (value: bigint): string => {
+	if (value <= 0n) {
+		return "0 bytes";
+	}
+	const hex = formatBigIntHex(value);
+	if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
+		return hex;
+	}
+	const units = ["bytes", "KiB", "MiB", "GiB", "TiB", "PiB"];
+	let size = Number(value);
+	let unitIndex = 0;
+	while (size >= 1024 && unitIndex < units.length - 1) {
+		size /= 1024;
+		unitIndex += 1;
+	}
+	const formatted = size >= 10 ? size.toFixed(0) : size.toFixed(1);
+	return `${hex} (${formatted} ${units[unitIndex]!})`;
+};
+
+const combineCellsToBigInt = (cells: number[]): bigint => {
+	if (!cells.length) {
+		return 0n;
+	}
+	return cells.reduce((acc, cell) => {
+		const truncated = Math.trunc(cell);
+		const normalized = BigInt.asUintN(32, BigInt(truncated));
+		return (acc << 32n) + normalized;
+	}, 0n);
+};
+
+const normalizeRegValue = (value: DtsValue): number[][] => {
+	const groups: number[][] = [];
+	const pushGroup = (candidate: unknown) => {
+		const numbers = collectNumbersFromValue(candidate as DtsValue);
+		if (numbers.length) {
+			groups.push(numbers);
+		}
+	};
+
+	if (Array.isArray(value)) {
+		if (value.length && Array.isArray(value[0])) {
+			value.forEach((group) => pushGroup(group));
+			return groups;
+		}
+		pushGroup(value);
+		return groups;
+	}
+
+	pushGroup(value);
+	return groups;
+};
+
+const getNumericPropertyValue = (
+	node: DtsNode,
+	name: string,
+): number | null => {
+	const property = node.properties.find((prop) => prop.name === name);
+	if (!property) {
+		return null;
+	}
+	const numbers = collectNumbersFromValue(property.value);
+	if (!numbers.length) {
+		return null;
+	}
+	return numbers[0] ?? null;
+};
+
+const getRegisterColor = (path: string): string => {
+	let color = registerColorByPath.get(path);
+	if (!color) {
+		color =
+			REGISTER_COLOR_PALETTE[
+				registerColorByPath.size % REGISTER_COLOR_PALETTE.length
+			] ?? "#1d4ed8";
+		registerColorByPath.set(path, color);
+	}
+	return color;
+};
+
+const renderRegisterMap = () => {
+	if (
+		!registerMapTrack ||
+		!registerMapLegend ||
+		!registerMapStatus ||
+		!registerMapAxis
+	) {
+		return;
+	}
+
+	registerMapTrack.innerHTML = "";
+	registerMapLegend.innerHTML = "";
+	registerMapAxis.innerHTML = "";
+
+	const hasRanges = registerRanges.length > 0;
+	registerMapTrack.classList.toggle("hidden", !hasRanges);
+	registerMapLegend.classList.toggle("hidden", !hasRanges);
+	registerMapAxis.classList.toggle("hidden", !hasRanges);
+
+	if (!hasRanges) {
+		registerMapStatus.textContent = currentRoot
+			? "No register ranges detected in this tree."
+			: "Load a DTS file to view its register map.";
+		return;
+	}
+
+	const minBase = registerRanges.reduce(
+		(min, range) => (range.base < min ? range.base : min),
+		registerRanges[0]!.base,
+	);
+	const maxEnd = registerRanges.reduce(
+		(max, range) => (range.end > max ? range.end : max),
+		registerRanges[0]!.end,
+	);
+	const span = maxEnd > minBase ? maxEnd - minBase : 0n;
+	const totalSpan = span > 0n ? span : 1n;
+	const percentScale = 10000n;
+
+	const regionLabel =
+		registerRanges.length === 1
+			? "1 register region"
+			: `${registerRanges.length} register regions`;
+	const spanText = span > 0n ? formatByteSize(span) : "0 bytes";
+	registerMapStatus.textContent = `${regionLabel}. Address span ${formatBigIntHex(
+		minBase,
+	)} – ${formatBigIntHex(maxEnd)} (${spanText}).`;
+
+	const axisStart = document.createElement("span");
+	axisStart.textContent = formatBigIntHex(minBase);
+	const axisEnd = document.createElement("span");
+	axisEnd.textContent = formatBigIntHex(maxEnd);
+	registerMapAxis.append(axisStart, axisEnd);
+
+	let cursor = minBase;
+	registerRanges.forEach((range) => {
+		if (range.base > cursor) {
+			const gap = range.base - cursor;
+			const gapUnits = Number((gap * percentScale) / totalSpan);
+			if (gapUnits > 0) {
+				const gapPercent = gapUnits / 100;
+				const gapElement = document.createElement("div");
+				gapElement.className = "register-gap";
+				gapElement.style.flex = `0 0 ${gapPercent}%`;
+				registerMapTrack.append(gapElement);
+			}
+		}
+
+		const layoutSize = range.size > 0n ? range.size : 0n;
+		const widthUnits =
+			layoutSize > 0n
+				? Number((layoutSize * percentScale) / totalSpan)
+				: 0;
+		const widthPercent = layoutSize > 0n ? widthUnits / 100 : 0;
+		const segment = document.createElement("button");
+		segment.type = "button";
+		segment.className = "register-segment";
+		if (selectedNodePath === range.node.path) {
+			segment.classList.add("selected");
+		}
+		const color = getRegisterColor(range.node.path);
+		segment.style.backgroundColor = color;
+		segment.style.minWidth = "6px";
+		if (layoutSize > 0n) {
+			segment.style.flex = `0 0 ${widthPercent}%`;
+		} else {
+			segment.style.flex = "0 0 auto";
+			segment.style.width = "6px";
+		}
+		const label = range.node.label
+			? `${range.node.label}: ${range.node.fullName}`
+			: range.node.fullName;
+		const end = range.size > 0n ? range.end : range.base;
+		const sizeText = formatByteSize(range.size);
+		segment.title =
+			range.size > 0n
+				? `${label} — ${formatBigIntHex(range.base)} to ${formatBigIntHex(
+						end,
+					)} (${sizeText})`
+				: `${label} — ${formatBigIntHex(range.base)} (size: 0)`;
+		segment.addEventListener("click", () => {
+			focusNodeByPath(range.node.path);
+		});
+		registerMapTrack.append(segment);
+
+		if (range.end > cursor) {
+			cursor = range.end;
+		}
+	});
+
+	const legendTable = document.createElement("table");
+	const thead = document.createElement("thead");
+	const headerRow = document.createElement("tr");
+	["", "Node", "Start", "End", "Size"].forEach((heading) => {
+		const th = document.createElement("th");
+		th.textContent = heading;
+		headerRow.append(th);
+	});
+	thead.append(headerRow);
+	legendTable.append(thead);
+
+	const tbody = document.createElement("tbody");
+	registerRanges.forEach((range) => {
+		const row = document.createElement("tr");
+		if (selectedNodePath === range.node.path) {
+			row.classList.add("selected");
+		}
+
+		const swatchCell = document.createElement("td");
+		const swatch = document.createElement("span");
+		swatch.className = "register-swatch";
+		swatch.style.backgroundColor = getRegisterColor(range.node.path);
+		swatchCell.append(swatch);
+
+		const nodeCell = document.createElement("td");
+		const nodeButton = document.createElement("button");
+		nodeButton.type = "button";
+		nodeButton.className = "register-link";
+		nodeButton.textContent = range.node.label
+			? `${range.node.label}: ${range.node.fullName}`
+			: range.node.fullName;
+		nodeButton.addEventListener("click", () => {
+			focusNodeByPath(range.node.path);
+		});
+		nodeCell.append(nodeButton);
+
+		const startCell = document.createElement("td");
+		startCell.textContent = formatBigIntHex(range.base);
+
+		const endCell = document.createElement("td");
+		endCell.textContent = formatBigIntHex(
+			range.size > 0n ? range.end : range.base,
+		);
+
+		const sizeCell = document.createElement("td");
+		sizeCell.textContent = formatByteSize(range.size);
+
+		row.append(swatchCell, nodeCell, startCell, endCell, sizeCell);
+		tbody.append(row);
+	});
+
+	legendTable.append(tbody);
+	registerMapLegend.append(legendTable);
+};
+
+const computeRegisterRanges = (root: DtsNode | null) => {
+	registerRanges = [];
+	registerColorByPath.clear();
+	if (!root) {
+		renderRegisterMap();
+		return;
+	}
+
+	const ranges: RegisterRange[] = [];
+	const visit = (node: DtsNode, parentSpec: CellSpec) => {
+		const regProperty = node.properties.find((prop) => prop.name === "reg");
+		if (regProperty) {
+			const groups = normalizeRegValue(regProperty.value);
+			const addressCells = Math.max(0, parentSpec.addressCells);
+			const sizeCells = Math.max(0, parentSpec.sizeCells);
+			const chunkSize = addressCells + sizeCells;
+			if (chunkSize > 0) {
+				groups.forEach((group) => {
+					if (group.length < chunkSize) {
+						return;
+					}
+					for (
+						let offset = 0;
+						offset + chunkSize <= group.length;
+						offset += chunkSize
+					) {
+						const addressSlice = group.slice(
+							offset,
+							offset + addressCells,
+						);
+						const sizeSlice = group.slice(
+							offset + addressCells,
+							offset + chunkSize,
+						);
+						const base = combineCellsToBigInt(addressSlice);
+						const size =
+							sizeCells > 0
+								? combineCellsToBigInt(sizeSlice)
+								: 0n;
+						const end = size > 0n ? base + size : base;
+						ranges.push({ node, base, size, end });
+					}
+				});
+			}
+		}
+
+		const nextSpec: CellSpec = {
+			addressCells:
+				getNumericPropertyValue(node, "#address-cells") ??
+				parentSpec.addressCells,
+			sizeCells:
+				getNumericPropertyValue(node, "#size-cells") ??
+				parentSpec.sizeCells,
+		};
+
+		node.children.forEach((child) => visit(child, nextSpec));
+	};
+
+	visit(root, DEFAULT_CELL_SPEC);
+
+	ranges.sort((a, b) => {
+		if (a.base === b.base) {
+			if (a.size === b.size) {
+				return a.node.path.localeCompare(b.node.path);
+			}
+			return a.size < b.size ? -1 : 1;
+		}
+		return a.base < b.base ? -1 : 1;
+	});
+
+	registerRanges = ranges;
+	renderRegisterMap();
+};
+
 const renderDetails = (node: DtsNode | null) => {
 	if (!detailsContent || !detailsTitle) {
 		return;
 	}
+
+	renderRegisterMap();
 
 	detailsContent.innerHTML = "";
 
@@ -1328,6 +1693,7 @@ const displayTree = (source: string, origin: string) => {
 		selectedNodePath = null;
 		selectedNode = null;
 		rebuildNodeIndexes(null);
+		computeRegisterRanges(null);
 		renderDetails(null);
 		return;
 	}
@@ -1339,6 +1705,7 @@ const displayTree = (source: string, origin: string) => {
 	activeFilterRaw = "";
 	activeFilterNormalized = "";
 	rebuildNodeIndexes(currentRoot);
+	computeRegisterRanges(currentRoot);
 	renderDetails(null);
 	if (canvas) {
 		canvas.style.cursor = "default";
@@ -2045,4 +2412,5 @@ if (!ctx) {
 	);
 } else {
 	attachEventHandlers();
+	renderRegisterMap();
 }

--- a/app.ts
+++ b/app.ts
@@ -1,5 +1,6 @@
 import { dtsPare } from "./dts";
 import type { DtsNode, DtsProperty, DtsValue } from "./dts";
+import { createRegisterMap, type RegisterMapController } from "./register-map";
 import {
 	CANVAS_PADDING,
 	NODE_GAP,
@@ -912,384 +913,23 @@ type PropertyLink = PropertyReference;
 const resolvePropertyLinks = (property: DtsProperty): PropertyLink[] =>
 	collectPropertyReferences(property);
 
-type RegisterRange = {
-	node: DtsNode;
-	base: bigint;
-	size: bigint;
-	end: bigint;
-};
-
-type CellSpec = {
-	addressCells: number;
-	sizeCells: number;
-};
-
-const DEFAULT_CELL_SPEC: CellSpec = {
-	addressCells: 1,
-	sizeCells: 1,
-};
-
-const REGISTER_COLOR_PALETTE = [
-	"#2563eb",
-	"#16a34a",
-	"#d97706",
-	"#dc2626",
-	"#7c3aed",
-	"#0891b2",
-	"#f97316",
-	"#0f766e",
-	"#a855f7",
-	"#9333ea",
-];
-
-let registerRanges: RegisterRange[] = [];
-const registerColorByPath = new Map<string, string>();
-let isRegisterMapExpanded = false;
-
-const formatBigIntHex = (value: bigint): string => `0x${value.toString(16)}`;
-
-const formatByteSize = (value: bigint): string => {
-	if (value <= 0n) {
-		return "0 bytes";
-	}
-	const hex = formatBigIntHex(value);
-	if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
-		return hex;
-	}
-	const units = ["bytes", "KiB", "MiB", "GiB", "TiB", "PiB"];
-	let size = Number(value);
-	let unitIndex = 0;
-	while (size >= 1024 && unitIndex < units.length - 1) {
-		size /= 1024;
-		unitIndex += 1;
-	}
-	const formatted = size >= 10 ? size.toFixed(0) : size.toFixed(1);
-	return `${hex} (${formatted} ${units[unitIndex]!})`;
-};
-
-const combineCellsToBigInt = (cells: number[]): bigint => {
-	if (!cells.length) {
-		return 0n;
-	}
-	return cells.reduce((acc, cell) => {
-		const truncated = Math.trunc(cell);
-		const normalized = BigInt.asUintN(32, BigInt(truncated));
-		return (acc << 32n) + normalized;
-	}, 0n);
-};
-
-const normalizeRegValue = (value: DtsValue): number[][] => {
-	const groups: number[][] = [];
-	const pushGroup = (candidate: unknown) => {
-		const numbers = collectNumbersFromValue(candidate as DtsValue);
-		if (numbers.length) {
-			groups.push(numbers);
-		}
-	};
-
-	if (Array.isArray(value)) {
-		if (value.length && Array.isArray(value[0])) {
-			value.forEach((group) => pushGroup(group));
-			return groups;
-		}
-		pushGroup(value);
-		return groups;
-	}
-
-	pushGroup(value);
-	return groups;
-};
-
-const getNumericPropertyValue = (
-	node: DtsNode,
-	name: string,
-): number | null => {
-	const property = node.properties.find((prop) => prop.name === name);
-	if (!property) {
-		return null;
-	}
-	const numbers = collectNumbersFromValue(property.value);
-	if (!numbers.length) {
-		return null;
-	}
-	return numbers[0] ?? null;
-};
-
-const getRegisterColor = (path: string): string => {
-        let color = registerColorByPath.get(path);
-        if (!color) {
-                color =
-                        REGISTER_COLOR_PALETTE[
-                                registerColorByPath.size % REGISTER_COLOR_PALETTE.length
-                        ] ?? "#1d4ed8";
-                registerColorByPath.set(path, color);
-        }
-        return color;
-};
-
-const setRegisterMapExpansion = (expanded: boolean) => {
-        isRegisterMapExpanded = expanded;
-        registerMapPanel?.classList.toggle("collapsed", !expanded);
-        if (registerMapToggle) {
-                registerMapToggle.textContent = expanded
-                        ? "Hide register map"
-                        : "Show register map";
-                registerMapToggle.setAttribute(
-                        "aria-expanded",
-                        expanded ? "true" : "false",
-                );
-        }
-};
-
-const renderRegisterMap = () => {
-	if (
-		!registerMapTrack ||
-		!registerMapLegend ||
-		!registerMapStatus ||
-		!registerMapAxis
-	) {
-		return;
-	}
-
-	registerMapTrack.innerHTML = "";
-	registerMapLegend.innerHTML = "";
-	registerMapAxis.innerHTML = "";
-
-	const hasRanges = registerRanges.length > 0;
-        registerMapTrack.classList.toggle("hidden", !hasRanges);
-        registerMapLegend.classList.toggle("hidden", !hasRanges);
-        registerMapAxis.classList.toggle("hidden", !hasRanges);
-
-        if (registerMapToggle) {
-                registerMapToggle.disabled = !hasRanges;
-        }
-
-        if (!hasRanges) {
-                setRegisterMapExpansion(false);
-                registerMapStatus.textContent = currentRoot
-                        ? "No register ranges detected in this tree."
-                        : "Load a DTS file to view its register map.";
-                return;
-        }
-
-	const minBase = registerRanges.reduce(
-		(min, range) => (range.base < min ? range.base : min),
-		registerRanges[0]!.base,
-	);
-	const maxEnd = registerRanges.reduce(
-		(max, range) => (range.end > max ? range.end : max),
-		registerRanges[0]!.end,
-	);
-	const span = maxEnd > minBase ? maxEnd - minBase : 0n;
-	const totalSpan = span > 0n ? span : 1n;
-	const percentScale = 10000n;
-
-	const regionLabel =
-		registerRanges.length === 1
-			? "1 register region"
-			: `${registerRanges.length} register regions`;
-	const spanText = span > 0n ? formatByteSize(span) : "0 bytes";
-	registerMapStatus.textContent = `${regionLabel}. Address span ${formatBigIntHex(
-		minBase,
-	)} – ${formatBigIntHex(maxEnd)} (${spanText}).`;
-
-	const axisStart = document.createElement("span");
-	axisStart.textContent = formatBigIntHex(minBase);
-	const axisEnd = document.createElement("span");
-	axisEnd.textContent = formatBigIntHex(maxEnd);
-	registerMapAxis.append(axisStart, axisEnd);
-
-	let cursor = minBase;
-	registerRanges.forEach((range) => {
-		if (range.base > cursor) {
-			const gap = range.base - cursor;
-			const gapUnits = Number((gap * percentScale) / totalSpan);
-			if (gapUnits > 0) {
-				const gapPercent = gapUnits / 100;
-				const gapElement = document.createElement("div");
-				gapElement.className = "register-gap";
-				gapElement.style.flex = `0 0 ${gapPercent}%`;
-				registerMapTrack.append(gapElement);
-			}
-		}
-
-		const layoutSize = range.size > 0n ? range.size : 0n;
-		const widthUnits =
-			layoutSize > 0n
-				? Number((layoutSize * percentScale) / totalSpan)
-				: 0;
-		const widthPercent = layoutSize > 0n ? widthUnits / 100 : 0;
-		const segment = document.createElement("button");
-		segment.type = "button";
-		segment.className = "register-segment";
-		if (selectedNodePath === range.node.path) {
-			segment.classList.add("selected");
-		}
-		const color = getRegisterColor(range.node.path);
-		segment.style.backgroundColor = color;
-		segment.style.minWidth = "6px";
-		if (layoutSize > 0n) {
-			segment.style.flex = `0 0 ${widthPercent}%`;
-		} else {
-			segment.style.flex = "0 0 auto";
-			segment.style.width = "6px";
-		}
-		const label = range.node.label
-			? `${range.node.label}: ${range.node.fullName}`
-			: range.node.fullName;
-		const end = range.size > 0n ? range.end : range.base;
-		const sizeText = formatByteSize(range.size);
-		segment.title =
-			range.size > 0n
-				? `${label} — ${formatBigIntHex(range.base)} to ${formatBigIntHex(
-						end,
-					)} (${sizeText})`
-				: `${label} — ${formatBigIntHex(range.base)} (size: 0)`;
-		segment.addEventListener("click", () => {
-			focusNodeByPath(range.node.path);
-		});
-		registerMapTrack.append(segment);
-
-		if (range.end > cursor) {
-			cursor = range.end;
-		}
-	});
-
-	const legendTable = document.createElement("table");
-	const thead = document.createElement("thead");
-	const headerRow = document.createElement("tr");
-	["", "Node", "Start", "End", "Size"].forEach((heading) => {
-		const th = document.createElement("th");
-		th.textContent = heading;
-		headerRow.append(th);
-	});
-	thead.append(headerRow);
-	legendTable.append(thead);
-
-	const tbody = document.createElement("tbody");
-	registerRanges.forEach((range) => {
-		const row = document.createElement("tr");
-		if (selectedNodePath === range.node.path) {
-			row.classList.add("selected");
-		}
-
-		const swatchCell = document.createElement("td");
-		const swatch = document.createElement("span");
-		swatch.className = "register-swatch";
-		swatch.style.backgroundColor = getRegisterColor(range.node.path);
-		swatchCell.append(swatch);
-
-		const nodeCell = document.createElement("td");
-		const nodeButton = document.createElement("button");
-		nodeButton.type = "button";
-		nodeButton.className = "register-link";
-		nodeButton.textContent = range.node.label
-			? `${range.node.label}: ${range.node.fullName}`
-			: range.node.fullName;
-		nodeButton.addEventListener("click", () => {
-			focusNodeByPath(range.node.path);
-		});
-		nodeCell.append(nodeButton);
-
-		const startCell = document.createElement("td");
-		startCell.textContent = formatBigIntHex(range.base);
-
-		const endCell = document.createElement("td");
-		endCell.textContent = formatBigIntHex(
-			range.size > 0n ? range.end : range.base,
-		);
-
-		const sizeCell = document.createElement("td");
-		sizeCell.textContent = formatByteSize(range.size);
-
-		row.append(swatchCell, nodeCell, startCell, endCell, sizeCell);
-		tbody.append(row);
-	});
-
-	legendTable.append(tbody);
-	registerMapLegend.append(legendTable);
-};
-
-const computeRegisterRanges = (root: DtsNode | null) => {
-	registerRanges = [];
-	registerColorByPath.clear();
-	if (!root) {
-		renderRegisterMap();
-		return;
-	}
-
-	const ranges: RegisterRange[] = [];
-	const visit = (node: DtsNode, parentSpec: CellSpec) => {
-		const regProperty = node.properties.find((prop) => prop.name === "reg");
-		if (regProperty) {
-			const groups = normalizeRegValue(regProperty.value);
-			const addressCells = Math.max(0, parentSpec.addressCells);
-			const sizeCells = Math.max(0, parentSpec.sizeCells);
-			const chunkSize = addressCells + sizeCells;
-			if (chunkSize > 0) {
-				groups.forEach((group) => {
-					if (group.length < chunkSize) {
-						return;
-					}
-					for (
-						let offset = 0;
-						offset + chunkSize <= group.length;
-						offset += chunkSize
-					) {
-						const addressSlice = group.slice(
-							offset,
-							offset + addressCells,
-						);
-						const sizeSlice = group.slice(
-							offset + addressCells,
-							offset + chunkSize,
-						);
-						const base = combineCellsToBigInt(addressSlice);
-						const size =
-							sizeCells > 0
-								? combineCellsToBigInt(sizeSlice)
-								: 0n;
-						const end = size > 0n ? base + size : base;
-						ranges.push({ node, base, size, end });
-					}
-				});
-			}
-		}
-
-		const nextSpec: CellSpec = {
-			addressCells:
-				getNumericPropertyValue(node, "#address-cells") ??
-				parentSpec.addressCells,
-			sizeCells:
-				getNumericPropertyValue(node, "#size-cells") ??
-				parentSpec.sizeCells,
-		};
-
-		node.children.forEach((child) => visit(child, nextSpec));
-	};
-
-	visit(root, DEFAULT_CELL_SPEC);
-
-	ranges.sort((a, b) => {
-		if (a.base === b.base) {
-			if (a.size === b.size) {
-				return a.node.path.localeCompare(b.node.path);
-			}
-			return a.size < b.size ? -1 : 1;
-		}
-		return a.base < b.base ? -1 : 1;
-	});
-
-	registerRanges = ranges;
-	renderRegisterMap();
-};
+const registerMap: RegisterMapController = createRegisterMap({
+        panel: registerMapPanel,
+        toggle: registerMapToggle,
+        status: registerMapStatus,
+        track: registerMapTrack,
+        legend: registerMapLegend,
+        axis: registerMapAxis,
+        onFocusNode: focusNodeByPath,
+        collectNumbersFromValue,
+});
 
 const renderDetails = (node: DtsNode | null) => {
 	if (!detailsContent || !detailsTitle) {
 		return;
 	}
 
-	renderRegisterMap();
+        registerMap.setSelection(node?.path ?? null);
 
 	detailsContent.innerHTML = "";
 
@@ -1717,7 +1357,7 @@ const displayTree = (source: string, origin: string) => {
 		selectedNodePath = null;
 		selectedNode = null;
 		rebuildNodeIndexes(null);
-		computeRegisterRanges(null);
+                registerMap.updateRanges(null);
 		renderDetails(null);
 		return;
 	}
@@ -1729,7 +1369,7 @@ const displayTree = (source: string, origin: string) => {
 	activeFilterRaw = "";
 	activeFilterNormalized = "";
 	rebuildNodeIndexes(currentRoot);
-	computeRegisterRanges(currentRoot);
+        registerMap.updateRanges(currentRoot);
 	renderDetails(null);
 	if (canvas) {
 		canvas.style.cursor = "default";
@@ -2141,10 +1781,6 @@ const attachEventHandlers = () => {
                 displayTree(SAMPLE_DTS, "Sample DTS");
         });
 
-        registerMapToggle?.addEventListener("click", () => {
-                setRegisterMapExpansion(!isRegisterMapExpanded);
-        });
-
         warningsToggle?.addEventListener("change", () => {
                 renderWarningsPanel();
                 if (lastStatus) {
@@ -2433,14 +2069,13 @@ const attachEventHandlers = () => {
 	});
 };
 
-setRegisterMapExpansion(false);
+registerMap.setExpanded(false);
 
 if (!ctx) {
-	statusElement?.classList.add("error");
-	statusElement?.append(
-		"\nCanvas rendering context unavailable in this browser.",
-	);
+        statusElement?.classList.add("error");
+        statusElement?.append(
+                "\nCanvas rendering context unavailable in this browser.",
+        );
 } else {
-	attachEventHandlers();
-	renderRegisterMap();
+        attachEventHandlers();
 }

--- a/index.html
+++ b/index.html
@@ -295,42 +295,90 @@
 				border-bottom: none;
 			}
 
-			#register-map-panel {
-				margin-top: 1.25rem;
-				border: 1px solid rgba(128, 128, 128, 0.35);
-				border-radius: 8px;
-				padding: 1rem 1.25rem;
-				background: rgba(248, 250, 252, 0.75);
-				display: flex;
-				flex-direction: column;
-				gap: 0.75rem;
-			}
+                        #register-map-panel {
+                                margin-top: 1.25rem;
+                                border: 1px solid rgba(128, 128, 128, 0.35);
+                                border-radius: 8px;
+                                padding: 1rem 1.25rem;
+                                background: rgba(248, 250, 252, 0.75);
+                                display: flex;
+                                flex-direction: column;
+                                gap: 0.75rem;
+                        }
 
-			#register-map-panel h2 {
-				margin: 0;
-				font-size: 1.05rem;
-			}
+                        #register-map-panel h2 {
+                                margin: 0;
+                                font-size: 1.05rem;
+                        }
 
-			#register-map-panel .panel-header {
-				display: flex;
-				flex-wrap: wrap;
-				gap: 0.65rem;
-				align-items: baseline;
-				justify-content: space-between;
-			}
+                        #register-map-panel .panel-header {
+                                display: flex;
+                                flex-wrap: wrap;
+                                gap: 0.65rem;
+                                align-items: flex-start;
+                                justify-content: space-between;
+                        }
 
-			#register-map-status {
-				margin: 0;
-				font-size: 0.9rem;
-				color: #475569;
-			}
+                        #register-map-panel .panel-title {
+                                display: flex;
+                                flex-direction: column;
+                                gap: 0.35rem;
+                        }
 
-			#register-map-axis {
-				display: flex;
-				justify-content: space-between;
-				font-family: "Cascadia Code", Consolas, monospace;
-				font-size: 0.85rem;
-				color: #475569;
+                        #register-map-status {
+                                margin: 0;
+                                font-size: 0.9rem;
+                                color: #475569;
+                        }
+
+                        #register-map-toggle {
+                                border: 1px solid rgba(148, 163, 184, 0.7);
+                                background: rgba(255, 255, 255, 0.9);
+                                color: #1d4ed8;
+                                font-weight: 600;
+                                border-radius: 999px;
+                                padding: 0.3rem 0.9rem;
+                                cursor: pointer;
+                                font-size: 0.85rem;
+                                transition: background 120ms ease, color 120ms ease,
+                                        border-color 120ms ease;
+                        }
+
+                        #register-map-toggle:hover {
+                                background: rgba(59, 130, 246, 0.1);
+                                border-color: rgba(37, 99, 235, 0.5);
+                                color: #1d4ed8;
+                        }
+
+                        #register-map-toggle:disabled {
+                                cursor: not-allowed;
+                                opacity: 0.55;
+                                color: #64748b;
+                                background: rgba(226, 232, 240, 0.6);
+                                border-color: rgba(148, 163, 184, 0.5);
+                        }
+
+                        #register-map-toggle:focus-visible {
+                                outline: 2px solid rgba(37, 99, 235, 0.6);
+                                outline-offset: 2px;
+                        }
+
+                        #register-map-content {
+                                display: flex;
+                                flex-direction: column;
+                                gap: 0.75rem;
+                        }
+
+                        #register-map-panel.collapsed #register-map-content {
+                                display: none;
+                        }
+
+                        #register-map-axis {
+                                display: flex;
+                                justify-content: space-between;
+                                font-family: "Cascadia Code", Consolas, monospace;
+                                font-size: 0.85rem;
+                                color: #475569;
 			}
 
 			#register-map-track {
@@ -577,15 +625,32 @@
 				</div>
 			</aside>
 		</main>
-		<section id="register-map-panel" aria-live="polite" aria-atomic="true">
-			<div class="panel-header">
-				<h2>Register map</h2>
-				<p id="register-map-status"></p>
-			</div>
-			<div id="register-map-axis" class="hidden"></div>
-			<div id="register-map-track" class="hidden"></div>
-			<div id="register-map-legend" class="hidden"></div>
-		</section>
+                <section
+                        id="register-map-panel"
+                        class="collapsed"
+                        aria-live="polite"
+                        aria-atomic="true"
+                >
+                        <div class="panel-header">
+                                <div class="panel-title">
+                                        <h2>Register map</h2>
+                                        <p id="register-map-status"></p>
+                                </div>
+                                <button
+                                        id="register-map-toggle"
+                                        type="button"
+                                        aria-expanded="false"
+                                        aria-controls="register-map-content"
+                                >
+                                        Show register map
+                                </button>
+                        </div>
+                        <div id="register-map-content">
+                                <div id="register-map-axis" class="hidden"></div>
+                                <div id="register-map-track" class="hidden"></div>
+                                <div id="register-map-legend" class="hidden"></div>
+                        </div>
+                </section>
 		<script type="module" src="app.ts"></script>
 	</body>
 </html>

--- a/index.html
+++ b/index.html
@@ -296,7 +296,8 @@
 			}
 
                         #register-map-panel {
-                                margin-top: 1.25rem;
+                                flex: 0 1 320px;
+                                min-width: min(320px, 100%);
                                 border: 1px solid rgba(128, 128, 128, 0.35);
                                 border-radius: 8px;
                                 padding: 1rem 1.25rem;
@@ -304,6 +305,8 @@
                                 display: flex;
                                 flex-direction: column;
                                 gap: 0.75rem;
+                                align-self: stretch;
+                                min-height: 0;
                         }
 
                         #register-map-panel h2 {
@@ -367,6 +370,9 @@
                                 display: flex;
                                 flex-direction: column;
                                 gap: 0.75rem;
+                                flex: 1 1 auto;
+                                min-height: 0;
+                                overflow-y: auto;
                         }
 
                         #register-map-panel.collapsed #register-map-content {
@@ -504,16 +510,20 @@
 				outline: none;
 			}
 
-			@media (max-width: 900px) {
-				main#workspace {
-					flex-direction: column;
-				}
+                        @media (max-width: 900px) {
+                                main#workspace {
+                                        flex-direction: column;
+                                }
 
-				#viewer-wrapper,
-				#details-panel {
-					min-width: 100%;
-				}
-			}
+                                #viewer-wrapper,
+                                #details-panel {
+                                        min-width: 100%;
+                                }
+
+                                #register-map-panel {
+                                        flex: 1 1 auto;
+                                }
+                        }
 
 			#drop-overlay {
 				position: fixed;
@@ -611,46 +621,46 @@
 				aria-atomic="true"
 			></pre>
 		</section>
-		<main id="workspace">
-			<div id="viewer-wrapper">
-				<canvas id="viewer-canvas"></canvas>
-			</div>
-			<aside id="details-panel" aria-live="polite" aria-atomic="true">
-				<h2 id="details-title">Node details</h2>
-				<div id="details-content">
-					<p>
-						Click any node in the tree to inspect its attributes and
-						properties.
-					</p>
-				</div>
-			</aside>
-		</main>
-                <section
-                        id="register-map-panel"
-                        class="collapsed"
-                        aria-live="polite"
-                        aria-atomic="true"
-                >
-                        <div class="panel-header">
-                                <div class="panel-title">
-                                        <h2>Register map</h2>
-                                        <p id="register-map-status"></p>
+                <main id="workspace">
+                        <aside
+                                id="register-map-panel"
+                                class="collapsed"
+                                aria-live="polite"
+                                aria-atomic="true"
+                        >
+                                <div class="panel-header">
+                                        <div class="panel-title">
+                                                <h2>Register map</h2>
+                                                <p id="register-map-status"></p>
+                                        </div>
+                                        <button
+                                                id="register-map-toggle"
+                                                type="button"
+                                                aria-expanded="false"
+                                                aria-controls="register-map-content"
+                                        >
+                                                Show register map
+                                        </button>
                                 </div>
-                                <button
-                                        id="register-map-toggle"
-                                        type="button"
-                                        aria-expanded="false"
-                                        aria-controls="register-map-content"
-                                >
-                                        Show register map
-                                </button>
+                                <div id="register-map-content">
+                                        <div id="register-map-axis" class="hidden"></div>
+                                        <div id="register-map-track" class="hidden"></div>
+                                        <div id="register-map-legend" class="hidden"></div>
+                                </div>
+                        </aside>
+                        <div id="viewer-wrapper">
+                                <canvas id="viewer-canvas"></canvas>
                         </div>
-                        <div id="register-map-content">
-                                <div id="register-map-axis" class="hidden"></div>
-                                <div id="register-map-track" class="hidden"></div>
-                                <div id="register-map-legend" class="hidden"></div>
-                        </div>
-                </section>
+                        <aside id="details-panel" aria-live="polite" aria-atomic="true">
+                                <h2 id="details-title">Node details</h2>
+                                <div id="details-content">
+                                        <p>
+                                                Click any node in the tree to inspect its attributes and
+                                                properties.
+                                        </p>
+                                </div>
+                        </aside>
+                </main>
 		<script type="module" src="app.ts"></script>
 	</body>
 </html>

--- a/index.html
+++ b/index.html
@@ -295,6 +295,167 @@
 				border-bottom: none;
 			}
 
+			#register-map-panel {
+				margin-top: 1.25rem;
+				border: 1px solid rgba(128, 128, 128, 0.35);
+				border-radius: 8px;
+				padding: 1rem 1.25rem;
+				background: rgba(248, 250, 252, 0.75);
+				display: flex;
+				flex-direction: column;
+				gap: 0.75rem;
+			}
+
+			#register-map-panel h2 {
+				margin: 0;
+				font-size: 1.05rem;
+			}
+
+			#register-map-panel .panel-header {
+				display: flex;
+				flex-wrap: wrap;
+				gap: 0.65rem;
+				align-items: baseline;
+				justify-content: space-between;
+			}
+
+			#register-map-status {
+				margin: 0;
+				font-size: 0.9rem;
+				color: #475569;
+			}
+
+			#register-map-axis {
+				display: flex;
+				justify-content: space-between;
+				font-family: "Cascadia Code", Consolas, monospace;
+				font-size: 0.85rem;
+				color: #475569;
+			}
+
+			#register-map-track {
+				display: flex;
+				align-items: stretch;
+				width: 100%;
+				height: 54px;
+				border-radius: 10px;
+				overflow: hidden;
+				border: 1px solid rgba(148, 163, 184, 0.45);
+				background: rgba(226, 232, 240, 0.5);
+			}
+
+			#register-map-track.hidden {
+				display: none;
+			}
+
+			#register-map-axis.hidden {
+				display: none;
+			}
+
+			#register-map-legend.hidden {
+				display: none;
+			}
+
+			.register-gap {
+				flex: 0 0 auto;
+				background: repeating-linear-gradient(
+					135deg,
+					rgba(148, 163, 184, 0.25),
+					rgba(148, 163, 184, 0.25) 8px,
+					rgba(203, 213, 225, 0.25) 8px,
+					rgba(203, 213, 225, 0.25) 16px
+				);
+			}
+
+			.register-segment {
+				flex: 0 0 auto;
+				border: none;
+				border-right: 1px solid rgba(15, 23, 42, 0.08);
+				background: rgba(59, 130, 246, 0.6);
+				cursor: pointer;
+				position: relative;
+				padding: 0;
+				transition:
+					transform 120ms ease,
+					box-shadow 120ms ease;
+				min-width: 4px;
+			}
+
+			.register-segment:last-child {
+				border-right: none;
+			}
+
+			.register-segment::after {
+				content: "";
+				position: absolute;
+				inset: 0;
+				background: linear-gradient(
+					to bottom,
+					rgba(255, 255, 255, 0.18),
+					rgba(255, 255, 255, 0.05)
+				);
+				pointer-events: none;
+			}
+
+			.register-segment:hover,
+			.register-segment:focus-visible {
+				transform: translateY(-1px);
+				box-shadow: 0 4px 10px rgba(15, 23, 42, 0.25);
+				outline: none;
+			}
+
+			.register-segment.selected {
+				outline: 2px solid rgba(29, 78, 216, 0.9);
+				outline-offset: -2px;
+				z-index: 1;
+			}
+
+			#register-map-legend table {
+				width: 100%;
+				border-collapse: collapse;
+				font-size: 0.9rem;
+			}
+
+			#register-map-legend th,
+			#register-map-legend td {
+				text-align: left;
+				padding: 0.35rem 0.4rem;
+				border-bottom: 1px solid rgba(148, 163, 184, 0.35);
+				vertical-align: middle;
+			}
+
+			#register-map-legend tbody tr:last-child td {
+				border-bottom: none;
+			}
+
+			#register-map-legend tbody tr.selected {
+				background: rgba(59, 130, 246, 0.12);
+			}
+
+			.register-swatch {
+				display: inline-block;
+				width: 0.85rem;
+				height: 0.85rem;
+				border-radius: 3px;
+				box-shadow: 0 0 0 1px rgba(15, 23, 42, 0.1);
+			}
+
+			.register-link {
+				background: none;
+				border: none;
+				padding: 0;
+				color: #1d4ed8;
+				cursor: pointer;
+				font: inherit;
+				text-align: left;
+			}
+
+			.register-link:hover,
+			.register-link:focus-visible {
+				text-decoration: underline;
+				outline: none;
+			}
+
 			@media (max-width: 900px) {
 				main#workspace {
 					flex-direction: column;
@@ -416,6 +577,15 @@
 				</div>
 			</aside>
 		</main>
+		<section id="register-map-panel" aria-live="polite" aria-atomic="true">
+			<div class="panel-header">
+				<h2>Register map</h2>
+				<p id="register-map-status"></p>
+			</div>
+			<div id="register-map-axis" class="hidden"></div>
+			<div id="register-map-track" class="hidden"></div>
+			<div id="register-map-legend" class="hidden"></div>
+		</section>
 		<script type="module" src="app.ts"></script>
 	</body>
 </html>

--- a/register-map.ts
+++ b/register-map.ts
@@ -1,0 +1,404 @@
+import type { DtsNode, DtsValue } from "./dts";
+
+const REGISTER_COLOR_PALETTE = [
+    "#2563eb",
+    "#16a34a",
+    "#d97706",
+    "#dc2626",
+    "#7c3aed",
+    "#0891b2",
+    "#f97316",
+    "#0f766e",
+    "#a855f7",
+    "#9333ea",
+];
+
+const DEFAULT_CELL_SPEC = {
+    addressCells: 1,
+    sizeCells: 1,
+};
+
+type CellSpec = {
+    addressCells: number;
+    sizeCells: number;
+};
+
+type RegisterRange = {
+    node: DtsNode;
+    base: bigint;
+    size: bigint;
+    end: bigint;
+};
+
+type RegisterMapElements = {
+    panel: HTMLElement | null;
+    toggle: HTMLButtonElement | null;
+    status: HTMLParagraphElement | null;
+    track: HTMLDivElement | null;
+    legend: HTMLDivElement | null;
+    axis: HTMLDivElement | null;
+};
+
+type RegisterMapOptions = RegisterMapElements & {
+    onFocusNode: (path: string) => void;
+    collectNumbersFromValue: (value: DtsValue) => number[];
+};
+
+export type RegisterMapController = {
+    setExpanded: (expanded: boolean) => void;
+    isExpanded: () => boolean;
+    updateRanges: (root: DtsNode | null) => void;
+    setSelection: (path: string | null) => void;
+};
+
+const formatBigIntHex = (value: bigint): string => `0x${value.toString(16)}`;
+
+const formatByteSize = (value: bigint): string => {
+    if (value <= 0n) {
+        return "0 bytes";
+    }
+    const hex = formatBigIntHex(value);
+    if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
+        return hex;
+    }
+    const units = ["bytes", "KiB", "MiB", "GiB", "TiB", "PiB"];
+    let size = Number(value);
+    let unitIndex = 0;
+    while (size >= 1024 && unitIndex < units.length - 1) {
+        size /= 1024;
+        unitIndex += 1;
+    }
+    const formatted = size >= 10 ? size.toFixed(0) : size.toFixed(1);
+    return `${hex} (${formatted} ${units[unitIndex]!})`;
+};
+
+const combineCellsToBigInt = (cells: number[]): bigint => {
+    if (!cells.length) {
+        return 0n;
+    }
+    return cells.reduce((acc, cell) => {
+        const truncated = Math.trunc(cell);
+        const normalized = BigInt.asUintN(32, BigInt(truncated));
+        return (acc << 32n) + normalized;
+    }, 0n);
+};
+
+const normalizeRegValue = (
+    value: DtsValue,
+    collectNumbersFromValue: (value: DtsValue) => number[],
+): number[][] => {
+    const groups: number[][] = [];
+    const pushGroup = (candidate: unknown) => {
+        const numbers = collectNumbersFromValue(candidate as DtsValue);
+        if (numbers.length) {
+            groups.push(numbers);
+        }
+    };
+
+    if (Array.isArray(value)) {
+        if (value.length && Array.isArray(value[0])) {
+            value.forEach((group) => pushGroup(group));
+            return groups;
+        }
+        pushGroup(value);
+        return groups;
+    }
+
+    pushGroup(value);
+    return groups;
+};
+
+const getNumericPropertyValue = (
+    node: DtsNode,
+    name: string,
+    collectNumbersFromValue: (value: DtsValue) => number[],
+): number | null => {
+    const property = node.properties.find((prop) => prop.name === name);
+    if (!property) {
+        return null;
+    }
+    const numbers = collectNumbersFromValue(property.value);
+    if (!numbers.length) {
+        return null;
+    }
+    return numbers[0] ?? null;
+};
+
+export const createRegisterMap = (
+    options: RegisterMapOptions,
+): RegisterMapController => {
+    const { panel, toggle, status, track, legend, axis, onFocusNode, collectNumbersFromValue } =
+        options;
+
+    let registerRanges: RegisterRange[] = [];
+    const registerColorByPath = new Map<string, string>();
+    let expanded = false;
+    let hasRoot = false;
+    let selection: string | null = null;
+
+    const applyExpansion = () => {
+        panel?.classList.toggle("collapsed", !expanded);
+        if (toggle) {
+            toggle.textContent = expanded ? "Hide register map" : "Show register map";
+            toggle.setAttribute("aria-expanded", expanded ? "true" : "false");
+        }
+    };
+
+    const getRegisterColor = (path: string): string => {
+        let color = registerColorByPath.get(path);
+        if (!color) {
+            color =
+                REGISTER_COLOR_PALETTE[registerColorByPath.size % REGISTER_COLOR_PALETTE.length] ??
+                "#1d4ed8";
+            registerColorByPath.set(path, color);
+        }
+        return color;
+    };
+
+    const render = () => {
+        if (!track || !legend || !status || !axis) {
+            return;
+        }
+
+        track.innerHTML = "";
+        legend.innerHTML = "";
+        axis.innerHTML = "";
+
+        const hasRanges = registerRanges.length > 0;
+        track.classList.toggle("hidden", !hasRanges);
+        legend.classList.toggle("hidden", !hasRanges);
+        axis.classList.toggle("hidden", !hasRanges);
+
+        if (toggle) {
+            toggle.disabled = !hasRanges;
+        }
+
+        if (!hasRanges) {
+            expanded = false;
+            applyExpansion();
+            status.textContent = hasRoot
+                ? "No register ranges detected in this tree."
+                : "Load a DTS file to view its register map.";
+            return;
+        }
+
+        applyExpansion();
+
+        const minBase = registerRanges.reduce(
+            (min, range) => (range.base < min ? range.base : min),
+            registerRanges[0]!.base,
+        );
+        const maxEnd = registerRanges.reduce(
+            (max, range) => (range.end > max ? range.end : max),
+            registerRanges[0]!.end,
+        );
+        const span = maxEnd > minBase ? maxEnd - minBase : 0n;
+        const totalSpan = span > 0n ? span : 1n;
+        const percentScale = 10000n;
+
+        const regionLabel =
+            registerRanges.length === 1
+                ? "1 register region"
+                : `${registerRanges.length} register regions`;
+        const spanText = span > 0n ? formatByteSize(span) : "0 bytes";
+        status.textContent = `${regionLabel}. Address span ${formatBigIntHex(minBase)} – ${formatBigIntHex(
+            maxEnd,
+        )} (${spanText}).`;
+
+        const axisStart = document.createElement("span");
+        axisStart.textContent = formatBigIntHex(minBase);
+        const axisEnd = document.createElement("span");
+        axisEnd.textContent = formatBigIntHex(maxEnd);
+        axis.append(axisStart, axisEnd);
+
+        let cursor = minBase;
+        registerRanges.forEach((range) => {
+            if (range.base > cursor) {
+                const gap = range.base - cursor;
+                const gapUnits = Number((gap * percentScale) / totalSpan);
+                if (gapUnits > 0) {
+                    const gapPercent = gapUnits / 100;
+                    const gapElement = document.createElement("div");
+                    gapElement.className = "register-gap";
+                    gapElement.style.flex = `0 0 ${gapPercent}%`;
+                    track.append(gapElement);
+                }
+            }
+
+            const layoutSize = range.size > 0n ? range.size : 0n;
+            const widthUnits = layoutSize > 0n ? Number((layoutSize * percentScale) / totalSpan) : 0;
+            const widthPercent = layoutSize > 0n ? widthUnits / 100 : 0;
+            const segment = document.createElement("button");
+            segment.type = "button";
+            segment.className = "register-segment";
+            if (selection === range.node.path) {
+                segment.classList.add("selected");
+            }
+            const color = getRegisterColor(range.node.path);
+            segment.style.backgroundColor = color;
+            segment.style.minWidth = "6px";
+            if (layoutSize > 0n) {
+                segment.style.flex = `0 0 ${widthPercent}%`;
+            } else {
+                segment.style.flex = "0 0 auto";
+                segment.style.width = "6px";
+            }
+            const label = range.node.label
+                ? `${range.node.label}: ${range.node.fullName}`
+                : range.node.fullName;
+            const end = range.size > 0n ? range.end : range.base;
+            const sizeText = formatByteSize(range.size);
+            segment.title =
+                range.size > 0n
+                    ? `${label} — ${formatBigIntHex(range.base)} to ${formatBigIntHex(end)} (${sizeText})`
+                    : `${label} — ${formatBigIntHex(range.base)} (size: 0)`;
+            segment.addEventListener("click", () => {
+                onFocusNode(range.node.path);
+            });
+            track.append(segment);
+
+            if (range.end > cursor) {
+                cursor = range.end;
+            }
+        });
+
+        const legendTable = document.createElement("table");
+        const thead = document.createElement("thead");
+        const headerRow = document.createElement("tr");
+        ["", "Node", "Start", "End", "Size"].forEach((heading) => {
+            const th = document.createElement("th");
+            th.textContent = heading;
+            headerRow.append(th);
+        });
+        thead.append(headerRow);
+        legendTable.append(thead);
+
+        const tbody = document.createElement("tbody");
+        registerRanges.forEach((range) => {
+            const row = document.createElement("tr");
+            if (selection === range.node.path) {
+                row.classList.add("selected");
+            }
+
+            const swatchCell = document.createElement("td");
+            const swatch = document.createElement("span");
+            swatch.className = "register-swatch";
+            swatch.style.backgroundColor = getRegisterColor(range.node.path);
+            swatchCell.append(swatch);
+
+            const nodeCell = document.createElement("td");
+            const nodeButton = document.createElement("button");
+            nodeButton.type = "button";
+            nodeButton.className = "register-link";
+            nodeButton.textContent = range.node.label
+                ? `${range.node.label}: ${range.node.fullName}`
+                : range.node.fullName;
+            nodeButton.addEventListener("click", () => {
+                onFocusNode(range.node.path);
+            });
+            nodeCell.append(nodeButton);
+
+            const startCell = document.createElement("td");
+            startCell.textContent = formatBigIntHex(range.base);
+
+            const endCell = document.createElement("td");
+            endCell.textContent = formatBigIntHex(range.size > 0n ? range.end : range.base);
+
+            const sizeCell = document.createElement("td");
+            sizeCell.textContent = formatByteSize(range.size);
+
+            row.append(swatchCell, nodeCell, startCell, endCell, sizeCell);
+            tbody.append(row);
+        });
+
+        legendTable.append(tbody);
+        legend.append(legendTable);
+    };
+
+    const updateRanges = (root: DtsNode | null) => {
+        registerRanges = [];
+        registerColorByPath.clear();
+        hasRoot = Boolean(root);
+        if (!root) {
+            render();
+            return;
+        }
+
+        const ranges: RegisterRange[] = [];
+        const visit = (node: DtsNode, parentSpec: CellSpec) => {
+            const regProperty = node.properties.find((prop) => prop.name === "reg");
+            if (regProperty) {
+                const groups = normalizeRegValue(regProperty.value, collectNumbersFromValue);
+                const addressCells = Math.max(0, parentSpec.addressCells);
+                const sizeCells = Math.max(0, parentSpec.sizeCells);
+                const chunkSize = addressCells + sizeCells;
+                if (chunkSize > 0) {
+                    groups.forEach((group) => {
+                        if (group.length < chunkSize) {
+                            return;
+                        }
+                        for (let offset = 0; offset + chunkSize <= group.length; offset += chunkSize) {
+                            const addressSlice = group.slice(offset, offset + addressCells);
+                            const sizeSlice = group.slice(offset + addressCells, offset + chunkSize);
+                            const base = combineCellsToBigInt(addressSlice);
+                            const size = sizeCells > 0 ? combineCellsToBigInt(sizeSlice) : 0n;
+                            const end = size > 0n ? base + size : base;
+                            ranges.push({ node, base, size, end });
+                        }
+                    });
+                }
+            }
+
+            const nextSpec: CellSpec = {
+                addressCells:
+                    getNumericPropertyValue(node, "#address-cells", collectNumbersFromValue) ??
+                    parentSpec.addressCells,
+                sizeCells:
+                    getNumericPropertyValue(node, "#size-cells", collectNumbersFromValue) ??
+                    parentSpec.sizeCells,
+            };
+
+            node.children.forEach((child) => visit(child, nextSpec));
+        };
+
+        visit(root, DEFAULT_CELL_SPEC);
+
+        ranges.sort((a, b) => {
+            if (a.base === b.base) {
+                if (a.size === b.size) {
+                    return a.node.path.localeCompare(b.node.path);
+                }
+                return a.size < b.size ? -1 : 1;
+            }
+            return a.base < b.base ? -1 : 1;
+        });
+
+        registerRanges = ranges;
+        render();
+    };
+
+    const setExpanded = (value: boolean) => {
+        expanded = value;
+        applyExpansion();
+    };
+
+    const setSelection = (path: string | null) => {
+        selection = path;
+        render();
+    };
+
+    toggle?.addEventListener("click", () => {
+        setExpanded(!expanded);
+    });
+
+    applyExpansion();
+    render();
+
+    return {
+        setExpanded,
+        isExpanded: () => expanded,
+        updateRanges,
+        setSelection,
+    };
+};
+


### PR DESCRIPTION
## Summary
- add a register map panel with styles and markup to display address coverage
- compute register ranges from `reg` properties and render clickable segments tied to tree nodes
- update initialization and selection flow to keep the register map in sync with the active tree

## Testing
- bun test
- bun run bundle

------
https://chatgpt.com/codex/tasks/task_e_68e492f54afc8326b72025b4a19e17d3